### PR TITLE
Manifest fixes which make the package usable again

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.ichi2.anki:api:1.1.0alpha6'
+    implementation 'com.github.ankidroid:Anki-Android:api-v1.1.0'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.is343.reactnativeankidroid">
-
+    <queries>
+        <package android:name="com.ichi2.anki" />
+    </queries>
 </manifest>
   


### PR DESCRIPTION
Hello,

I have found two issues with the current project:

1. The project has a dependency on `com.ichi2.anki:api:1.1.0alpha6` which is no longer valid. The new path that works is `com.github.ankidroid:Anki-Android:api-v1.1.0`.
2. The package name could not be resolved on my Android (which runs Android 11). It's a known issue and the fix has been included into the manifest as per documentation.

All of the above is per the most recent documentation: https://github.com/ankidroid/Anki-Android/wiki/AnkiDroid-API