### PR TITLE
Utilize FileProvider for uploading media

### DIFF
--- a/android/src/main/java/com/is343/reactnativeankidroid/AnkiDroidModule.java
+++ b/android/src/main/java/com/is343/reactnativeankidroid/AnkiDroidModule.java
@@ -10,9 +10,12 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.ListIterator;
+import java.io.File;
 import android.util.SparseArray;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.content.Intent;
+import androidx.core.content.FileProvider;
 
 import android.os.Build;
 import com.facebook.react.bridge.Promise;
@@ -65,9 +68,12 @@ public class AnkiDroidModule extends ReactContextBaseJavaModule {
    */
   @ReactMethod
   public void uploadMediaFromUri(String fileUri, String preferredName, String mimeType, Promise promise) {
-    Uri uri = Uri.parse(fileUri);
+    File file = new File(fileUri.replaceFirst("^file://", ""));
+    Uri uri = FileProvider.getUriForFile(mContext, mContext.getPackageName() + ".fileProvider", file);
+    mContext.grantUriPermission("com.ichi2.anki", uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
     String formatMediaName = mApi.addMediaFromUri(uri, preferredName, mimeType);
-    
+    mContext.revokeUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
     if (formatMediaName == null) {
       promise.reject("Failed to upload the file. URI: " + fileUri + "; preferredName: " + preferredName + "; mimeType: " + mimeType);
       return;

--- a/src/ankidroid.ts
+++ b/src/ankidroid.ts
@@ -272,7 +272,6 @@ export class AnkiDroid {
    * media file to be placed in the desired field of a card
    *
    * Notes to consider:
-   * * The file URI should be prefixed with `file://`
    * * Both AnkiDroid and your app should have the
    * `android.permission.MANAGE_EXTERNAL_STORAGE` permission granted if you wish
    * to upload the file from external storage


### PR DESCRIPTION
My previous PR had an implementation that caused problems with Android permissions. In short, it was impossible to upload the files *unless* you had the `MANAGE_EXTERNAL_STORAGE` permission enabled. It's problematic because the Google Play Store has some strict limitations on all the apps that use this permission. In light of this, I'm submitting a new implementation using `FileProvider`.

In order for the media to work, the consumer of this library will have to make the following changes to their Android source configuration:
1. Add a FileProvider into their `AndroidManifest.xml` with the `android:authorities` field set to `<their package name>.fileProvider`:
```
<provider
  android:name="androidx.core.content.FileProvider"
  android:authorities="com.example.app.fileProvider"
  android:grantUriPermissions="true"
  android:exported="false">
    <meta-data
      android:name="android.support.FILE_PROVIDER_PATHS"
      android:resource="@xml/file_paths" />
</provider>
``` 
2. Create a file paths configuration file over at `android/app/src/main/res/xml/file_paths.xml` and add paths that fits their App's needs (more info on the config file could be found [here](https://developer.android.com/reference/androidx/core/content/FileProvider)). Config that I use in my app:
```
<paths xmlns:android="http://schemas.android.com/apk/res/android">
    <external-files-path name="my_media" path="media/"/>
</paths>
```
  * The above allows Anki to read from files in the "media" folder located in my app's external files path.